### PR TITLE
Always try to pull a new image

### DIFF
--- a/deployments/ohw-hub/config/common.yaml
+++ b/deployments/ohw-hub/config/common.yaml
@@ -7,6 +7,8 @@ jupyterhub:
       guarantee: 512M
       #limit: 1G
     serviceAccountName: jovyan
+    image:
+      pullPolicy: "Always"
    # Only settings required to use the efs-provisioner
     storage:
       dynamic:


### PR DESCRIPTION
Should make the hub much more responsive to new images on DockerHub

@ocefpaf , I talked to Scott about how to make the JupyterHub more responsive to new DockerHub images and this was his suggestion! Should be much better.